### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ python frontendmasters-dl.py --help
 Usage: frontendmasters-dl.py [OPTIONS]
 
 Options:
-  --course TEXT     Course ID (e.g. `firebase-react`)
-  --id TEXT         Frontend Master Username
-  --password TEXT   Frontend Master Password
-  --mute-audio      Mute Frontend Master browser tab
-  --high-resolution Download high resolution videos
-  --help            Show this message and exit.
+  --course TEXT      Course ID (e.g. `firebase-react`)
+  --id TEXT          Frontend Master Username
+  --password TEXT    Frontend Master Password
+  --mute-audio       Mute Frontend Master browser tab
+  --high-resolution  Download high resolution videos
+  --video-per-video  Download one video at a time
+  --help             Show this message and exit.
 ```
 
 To download one particular course,


### PR DESCRIPTION
Added the video-per-video option to the readme as it is in the --help menu if you run in the command line but not here.

This actually really helped me as I was getting a "429: You have reached maximum request limit. Sleeping for 15 minutes" message if I tried to download all of the videos at once, and it wouldn't download anything. Using the video-by-video option seems to be working now.