### PR TITLE
Added a check for incorrect username/password

### DIFF
--- a/extractor/spider.py
+++ b/extractor/spider.py
@@ -45,6 +45,9 @@ class Spider(object):
         password_field.send_keys(Keys.RETURN)
 
     def download(self, course, high_resolution, video_per_video):
+        if self.browser.find_elements_by_class_name('Message'):
+            print "Your username/password was incorrect"
+            exit(1)
         # Get detailed course list
         course_detailed_list = self._get_detailed_course_list(course)
 


### PR DESCRIPTION
This seems dumb, but a lot of people got confused by this error enough that it became an issue:
https://github.com/li-xinyang/OS_FrontendMaster-dl/issues/75

There was no clear indication if you entered an incorrect username/password, it just proceeded to run the downloader and led to an error that made no sense.

This simply sends a message and closes the program if you entered the wrong username/password.

Should save people hours of frustration in the future.