### PR TITLE
fixed 'element not visible' when 'high-resolution' flag on

### DIFF
--- a/extractor/spider.py
+++ b/extractor/spider.py
@@ -177,6 +177,8 @@ class Spider(object):
                         time.sleep(10)
 
                     if high_resolution:
+                        big_play_button = self.browser.find_element_by_class_name('vjs-big-play-button')
+                        big_play_button.click()
                         resolution_button = self.browser.find_element_by_class_name("fm-vjs-quality")
                         resolution_button.click()
 


### PR DESCRIPTION
by clicking the "big_play_button" the control bar becomes visible hence we're able to select the high-resolution source
